### PR TITLE
cparse change: implicit void function

### DIFF
--- a/cparse_revised.py
+++ b/cparse_revised.py
@@ -99,7 +99,7 @@ def p_direct_declarator_6(t):
 
 def p_direct_declarator_7(t):
     """ direct_declarator : direct_declarator LPAREN RPAREN """
-    t[0] = t[1]
+    t[0] = (t[1],['void'])
 
 
 # constant-expression


### PR DESCRIPTION
Cparse change implicit void function to explicit 'void' function
For example, int main() function is converted into int main(void) and stored into AST